### PR TITLE
Reusable Media Queries with String Styles wasn't working:2

### DIFF
--- a/docs/media-queries.md
+++ b/docs/media-queries.md
@@ -91,11 +91,11 @@ const breakpoints = {
 
 const mq = Object.keys(breakpoints).reduce(
   (accumulator, label) => {
-    let suffix =
-      typeof breakpoints[label] === 'string' ? '' : 'px'
+    let prefix = typeof breakpoints[label] === 'string' ? '' : 'min-width:'
+    let suffix = typeof breakpoints[label] === 'string' ? '' : 'px'
     accumulator[label] = cls =>
       css`
-        @media (min-width:${breakpoints[label] + suffix}) {
+        @media (${prefix + breakpoints[label] + suffix}) {
           ${cls};
         }
       `


### PR DESCRIPTION
Updated with reference to the comments made by @mitchellhamilton.
The Prefix is now determined by whether the value is a string or not

